### PR TITLE
ice: backport XSK queue disable/enable fixes from upstream Linux

### DIFF
--- a/src/ice_xsk.c
+++ b/src/ice_xsk.c
@@ -61,7 +61,6 @@ static void ice_qp_clean_rings(struct ice_vsi *vsi, u16 q_idx)
 	ice_clean_tx_ring(vsi->tx_rings[q_idx]);
 	if (ice_is_xdp_ena_vsi(vsi))
 		ice_clean_tx_ring(vsi->xdp_rings[q_idx]);
-
 	ice_clean_rx_ring(vsi->rx_rings[q_idx]);
 }
 
@@ -170,7 +169,6 @@ static int ice_qp_dis(struct ice_vsi *vsi, u16 q_idx)
 	struct ice_q_vector *q_vector;
 	struct ice_tx_ring *tx_ring;
 	struct ice_rx_ring *rx_ring;
-	int timeout = 50;
 	int err;
 
 	if (q_idx >= vsi->num_rxq || q_idx >= vsi->num_txq)
@@ -180,15 +178,12 @@ static int ice_qp_dis(struct ice_vsi *vsi, u16 q_idx)
 	rx_ring = vsi->rx_rings[q_idx];
 	q_vector = rx_ring->q_vector;
 
-	while (test_and_set_bit(ICE_CFG_BUSY, vsi->back->state)) {
-		timeout--;
-		if (!timeout)
-			return -EBUSY;
-		usleep_range(1000, 2000);
-	}
+	synchronize_net();
+	netif_carrier_off(vsi->netdev);
 	netif_tx_stop_queue(netdev_get_tx_queue(vsi->netdev, q_idx));
 
 	ice_qvec_dis_irq(vsi, rx_ring, q_vector);
+	ice_qvec_toggle_napi(vsi, q_vector, false);
 
 	ice_fill_txq_meta(vsi, tx_ring, &txq_meta);
 	err = ice_vsi_stop_tx_ring(vsi, ICE_NO_RESET, 0, tx_ring, &txq_meta);
@@ -210,7 +205,6 @@ static int ice_qp_dis(struct ice_vsi *vsi, u16 q_idx)
 #ifdef HAVE_XSK_BATCHED_RX_ALLOC
 	ice_clean_rx_ring(rx_ring);
 #endif
-	ice_qvec_toggle_napi(vsi, q_vector, false);
 	ice_qp_clean_rings(vsi, q_idx);
 	ice_qp_reset_stats(vsi, q_idx);
 
@@ -230,6 +224,7 @@ static int ice_qp_ena(struct ice_vsi *vsi, u16 q_idx)
 	struct ice_q_vector *q_vector;
 	struct ice_tx_ring *tx_ring;
 	struct ice_rx_ring *rx_ring;
+	bool link_up;
 	u16 size;
 	int err;
 
@@ -274,11 +269,14 @@ static int ice_qp_ena(struct ice_vsi *vsi, u16 q_idx)
 	if (err)
 		goto free_buf;
 
-	clear_bit(ICE_CFG_BUSY, vsi->back->state);
 	ice_qvec_toggle_napi(vsi, q_vector, true);
 	ice_qvec_ena_irq(vsi, q_vector);
 
-	netif_tx_start_queue(netdev_get_tx_queue(vsi->netdev, q_idx));
+	ice_get_link_status(vsi->port_info, &link_up);
+	if (link_up) {
+		netif_tx_start_queue(netdev_get_tx_queue(vsi->netdev, q_idx));
+		netif_carrier_on(vsi->netdev);
+	}
 free_buf:
 	kfree(qg_buf);
 	return err;


### PR DESCRIPTION


  
  Backport 4 upstream commits that fix race conditions during AF_XDP/XSK
  socket setup/teardown causing false TX watchdog timeouts, NULL pointer
  dereferences, and workqueue deadlocks on ice 2.5.4:
  
  - [99099c6bc75a](https://github.com/torvalds/linux/commit/99099c6bc75a) ("ice: reorder disabling IRQ and NAPI in ice_qp_dis")
  - [405d9999aa0b](https://github.com/torvalds/linux/commit/405d9999aa0b) ("ice: replace synchronize_rcu with synchronize_net")
  - [9da75a511c55](https://github.com/torvalds/linux/commit/9da75a511c55) ("ice: toggle netif_carrier when setting up XSK pool")
  - [7e3b407ccbea](https://github.com/torvalds/linux/commit/7e3b407ccbea) ("ice: remove ICE_CFG_BUSY locking from AF_XDP code")
  
  All fix the original [2d4238f55697](https://github.com/torvalds/linux/commit/2d4238f55697) ("ice: Add support for AF_XDP").
  
  ## Problem
  
  During AF_XDP/XSK socket setup/teardown under TX load, the driver's queue
  reconfiguration takes longer than the 5-second watchdog timeout allows. The
  kernel incorrectly concludes the NIC has hung and triggers a PF reset. The
  reset frees ring pointers while concurrent operations are still accessing
  them, causing a NULL pointer dereference followed by a workqueue deadlock.
  The NIC never recovers — hosts become permanently unreachable.
  
  ## Fix
  
  These 4 commits collectively:
  1. Reorder NAPI disable before touching queues (closes stale interrupt window)
  2. Add `synchronize_net()` early in teardown (drains in-flight TX)
  3. Toggle `netif_carrier_off/on` (prevents watchdog from firing during reconfig)
  4. Remove `ICE_CFG_BUSY` busy-wait (was never protecting the queue pair)
  
  ## Backport methodology
  
  Cherry-pick was not possible due to API differences between upstream and
  the out-of-tree driver. The combined intent of all four patches was applied
  manually, preserving ice-2.5.4-specific code.
  
  ## Testing
  
  - Intel E810 (PCI 8086:1592), kernel 5.10.252/253
  - 64-thread UDP flood (upto ~200 Gbps)
  - Without patch: hosts crash within 1-4 XSK lifecycle iterations
  - With patch: hosts survive 200+ iterations under sustained load
   
   Related: #58, #61
